### PR TITLE
Fix typo in macro definition in Linear.h

### DIFF
--- a/Raytracer/Linear.h
+++ b/Raytracer/Linear.h
@@ -1,5 +1,5 @@
-#ifndef __INLCUDED_GAL_BASE_H__
-#define __INLCUDED_GAL_BASE_H__
+#ifndef __INCLUDED_GAL_BASE_H__
+#define __INCLUDED_GAL_BASE_H__
 /* FILE GAL/Linear.h
  *
  * Defines Point< Numeric_T, int > and Matrix< Numeric_T, int >
@@ -874,5 +874,5 @@ namespace GAL {
         }
 
 };//namespace GAL
-#endif//__INLCUDED_GAL_BASE_H__
+#endif//__INCLUDED_GAL_BASE_H__
 


### PR DESCRIPTION
Linear.h currently says: 

#ifndef __IN**LCU**DED_GAL_BASE_H__